### PR TITLE
Get zenoh-c as submodule instead of latest main in ci

### DIFF
--- a/.github/actions/build-zenoh-c/action.yml
+++ b/.github/actions/build-zenoh-c/action.yml
@@ -12,7 +12,8 @@ runs:
       id: clone-zenoh-c
       shell: bash
       run: |
-          git clone --depth 1 https://github.com/eclipse-zenoh/zenoh-c.git
+          git submodule init
+          git submodule update
           cd zenoh-c
           echo "rev=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "zenoh-c"]
+	path = zenoh-c
+	url = https://github.com/eclipse-zenoh/zenoh-c.git


### PR DESCRIPTION
Get zenoh-c as submodule instead of latest main in ci