### PR TITLE
chore:  add zenoh-c as submodule

### DIFF
--- a/.github/actions/build-zenoh-c/action.yml
+++ b/.github/actions/build-zenoh-c/action.yml
@@ -1,27 +1,33 @@
 name: build-zenoh-c
 
+description: Build Zenoh-C and install it in the specified prefix
+
 inputs:
   install-prefix:
-    description: 'Cmake install prefix'
+    description: "Cmake install prefix"
     required: true
-    
+
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: Clone Zenoh-C repository
-      id: clone-zenoh-c
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Init Zenoh-C submodule
+      id: init-zenoh-c
       shell: bash
       run: |
-          git clone --depth 1 https://github.com/eclipse-zenoh/zenoh-c.git
-          cd zenoh-c
-          echo "rev=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        git submodule update --init --recursive
+        cd zenoh-c
+        echo "rev=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     - name: Cache Zenoh-C dependencies
       id: cache-zenoh-c
       uses: actions/cache@v4
       with:
         path: ${{ inputs.install-prefix }}
-        key: ${{ runner.os }}-${{ runner.arch }}-${{steps.clone-zenoh-c.outputs.rev}}-zenoh-c
+        key: ${{ runner.os }}-${{ runner.arch }}-${{steps.init-zenoh-c.outputs.rev}}-zenoh-c
+
     - name: Build Zenoh-C
       if: steps.cache-zenoh-c.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: "1.22"
 
       - name: Build Zenoh-C dependencies
         uses: ./.github/actions/build-zenoh-c
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: "1.22"
 
       - name: Build Zenoh-C dependencies
         uses: ./.github/actions/build-zenoh-c
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: "1.22"
 
       - name: Clean Go Cache
         run: go clean --cache
@@ -81,7 +81,7 @@ jobs:
           export CGO_CFLAGS="-I/tmp/local/include"
           export CGO_LDFLAGS="-L/tmp/local/lib"
           export LD_LIBRARY_PATH="/tmp/local/lib"
-          make test 
+          make test
 
       - name: Build all examples
         run: |
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: "1.22"
 
       - name: Check code format
         run: make fmt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "zenoh-c"]
+	path = zenoh-c
+	url = https://github.com/eclipse-zenoh/zenoh-c


### PR DESCRIPTION
- Adds zenoh-c as a submodule of zenoh-go similar to how it's done for zenoh-cpp
- update the action to use the submodule, build and cache it.