### PR TITLE
connectivity api

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,4 @@
 [submodule "zenoh-c"]
 	path = zenoh-c
-	# To switch back to official: url = https://github.com/eclipse-zenoh/zenoh-c.git
-	url = https://github.com/milyin-zenoh-zbobr/zenoh-c.git
-	branch = zbobr_fix-60-transport-from-fields
+	url = https://github.com/eclipse-zenoh/zenoh-c.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "zenoh-c"]
 	path = zenoh-c
-	url = https://github.com/eclipse-zenoh/zenoh-c.git
+	# To switch back to official: url = https://github.com/eclipse-zenoh/zenoh-c.git
+	url = https://github.com/milyin-zenoh-zbobr/zenoh-c.git
+	branch = zbobr_fix-60-transport-from-fields

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,37 @@ Then build/test with:
 CGO_CFLAGS="-I$HOME/local/include" CGO_LDFLAGS="-L$HOME/local/lib -lzenohc" go build ./...
 CGO_CFLAGS="-I$HOME/local/include" CGO_LDFLAGS="-L$HOME/local/lib -lzenohc" go test ./...
 ```
+
+## CGo Conventions
+
+### C pointer conversion methods
+
+Methods that convert a Go struct to a C pointer are named `toCPtr` and live in the same file as the Go type. They return a pointer to a C-owned struct (e.g. `*C.z_owned_foo_t`). Prefer stack allocation over `C.malloc`:
+
+```go
+func (t Foo) toCPtr() *C.z_owned_foo_t {
+    var owned C.z_owned_foo_t
+    // ... fill owned from t ...
+    return &owned // escapes to heap via Go escape analysis
+}
+```
+
+Never use `C.malloc` / `C.free` for temporary C structs — Go's escape analysis handles heap promotion.
+
+### Lifetime bounds with runtime.Pinner
+
+When a C pointer is passed to a C function (e.g. via `z_foo_move`), use a `runtime.Pinner` at the call site to make the lifetime explicit:
+
+```go
+pinner := runtime.Pinner{}
+defer pinner.Unpin()
+ownedPtr := val.toCPtr()
+pinner.Pin(ownedPtr)
+cOpts.foo = C.z_foo_move(ownedPtr)
+```
+
+The pinner can be reused for multiple fields in the same scope.
+
+### Optional fields
+
+Fields that may or may not be present in the C API should be typed as `option.Option[T]` (from `github.com/BooleanCat/option`), not as a zero-value sentinel like `""` or `0`. This applies to both struct fields and method return types. Use `option.Some(v)` when the value is present and `option.None[T]()` (or zero-value `option.Option[T]{}`) when absent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# zenoh-go development notes
+
+## Building
+
+zenoh-go uses CGo and requires the zenoh-c library. Build and install it from the submodule:
+
+```sh
+git submodule init && git submodule update
+cd zenoh-c && mkdir -p build && cd build
+cmake .. -DZENOHC_BUILD_WITH_UNSTABLE_API=ON -DCMAKE_INSTALL_PREFIX="$HOME/local"
+cmake --build . --target install --config Release
+```
+
+Then build/test with:
+
+```sh
+CGO_CFLAGS="-I$HOME/local/include" CGO_LDFLAGS="-L$HOME/local/lib -lzenohc" go build ./...
+CGO_CFLAGS="-I$HOME/local/include" CGO_LDFLAGS="-L$HOME/local/lib -lzenohc" go test ./...
+```

--- a/examples/z_info/z_info.go
+++ b/examples/z_info/z_info.go
@@ -17,7 +17,9 @@ package main
 import (
 	"fmt"
 	"os"
-
+	"os/signal"
+	"strings"
+	"syscall"
 	"github.com/eclipse-zenoh/zenoh-go/examples/utils"
 
 	"github.com/eclipse-zenoh/zenoh-go/zenoh"
@@ -48,6 +50,56 @@ func main() {
 	for _, id := range ids {
 		fmt.Printf("%s\n", id)
 	}
+
+	// Warning: transport/link APIs are unstable.
+
+	fmt.Println("transports:")
+	transports, _ := session.Transports()
+	for _, tr := range transports {
+		fmt.Printf("  zid: %s, whatami: %s, qos: %v, multicast: %v\n",
+			tr.ZId(), tr.WhatAmI(), tr.IsQos(), tr.IsMulticast())
+	}
+
+	fmt.Println("links:")
+	links, _ := session.Links(nil)
+	for _, l := range links {
+		ifaces := strings.Join(l.Interfaces(), ", ")
+		fmt.Printf("  zid: %s, src: %s, dst: %s, mtu: %d, streamed: %v, interfaces: [%s]\n",
+			l.ZId(), l.Src(), l.Dst(), l.Mtu(), l.IsStreamed(), ifaces)
+	}
+
+	_ = session.DeclareBackgroundTransportEventsListener(
+		zenoh.Closure[zenoh.TransportEvent]{
+			Call: func(evt zenoh.TransportEvent) {
+				action := "Opened"
+				if evt.Kind() == zenoh.SampleKindDelete {
+					action = "Closed"
+				}
+				fmt.Printf("[Transport Event] %s: zid=%s\n", action, evt.ZId())
+			},
+		},
+		nil,
+	)
+
+	_ = session.DeclareBackgroundLinkEventsListener(
+		zenoh.Closure[zenoh.LinkEvent]{
+			Call: func(evt zenoh.LinkEvent) {
+				action := "Added"
+				if evt.Kind() == zenoh.SampleKindDelete {
+					action = "Removed"
+				}
+				fmt.Printf("[Link Event] %s: zid=%s, src=%s, dst=%s\n",
+					action, evt.ZId(), evt.Src(), evt.Dst())
+			},
+		},
+		nil,
+	)
+
+	fmt.Println("Monitoring connectivity events. Press CTRL-C to quit...")
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+	fmt.Println("Exiting...")
 }
 
 type Args struct {

--- a/examples/z_info/z_info.go
+++ b/examples/z_info/z_info.go
@@ -75,7 +75,7 @@ func main() {
 				if evt.Kind() == zenoh.SampleKindDelete {
 					action = "Closed"
 				}
-				fmt.Printf("[Transport Event] %s: zid=%s\n", action, evt.ZId())
+				fmt.Printf("[Transport Event] %s: zid=%s\n", action, evt.Transport().ZId())
 			},
 		},
 		nil,
@@ -89,7 +89,7 @@ func main() {
 					action = "Removed"
 				}
 				fmt.Printf("[Link Event] %s: zid=%s, src=%s, dst=%s\n",
-					action, evt.ZId(), evt.Src(), evt.Dst())
+					action, evt.Link().ZId(), evt.Link().Src(), evt.Link().Dst())
 			},
 		},
 		nil,

--- a/examples/z_info/z_info.go
+++ b/examples/z_info/z_info.go
@@ -16,11 +16,11 @@ package main
 
 import (
 	"fmt"
+	"github.com/eclipse-zenoh/zenoh-go/examples/utils"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
-	"github.com/eclipse-zenoh/zenoh-go/examples/utils"
 
 	"github.com/eclipse-zenoh/zenoh-go/zenoh"
 )

--- a/tests/connectivity_test.go
+++ b/tests/connectivity_test.go
@@ -371,8 +371,8 @@ func TestLinkAccessors(t *testing.T) {
 	assert.Empty(t, links[0].AuthIdentifier())
 
 	// Just verify these accessors don't panic
-	_, _, _ = links[0].Priorities()
-	_, _ = links[0].Reliability()
+	_ = links[0].Priorities()
+	_ = links[0].Reliability()
 
 	// Verify ZId matches s2
 	assert.Equal(t, s2.ZId().String(), links[0].ZId().String())

--- a/tests/connectivity_test.go
+++ b/tests/connectivity_test.go
@@ -486,3 +486,106 @@ func TestBackgroundLinkEventsListener(t *testing.T) {
 	assert.Equal(t, 2, len(events))
 	assert.Equal(t, zenoh.SampleKindDelete, events[1].Kind())
 }
+
+func TestBackgroundTransportEventsListenerWithHistory(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17967)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	s2ZId := s2.ZId()
+	var events []zenoh.TransportEvent
+
+	// Declare listener with history — should receive event for already-existing transport
+	err := s1.DeclareBackgroundTransportEventsListener(
+		zenoh.Closure[zenoh.TransportEvent]{
+			Call: func(evt zenoh.TransportEvent) { events = append(events, evt) },
+		},
+		&zenoh.TransportEventsListenerOptions{History: true},
+	)
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, 1, len(events))
+	assert.Equal(t, zenoh.SampleKindPut, events[0].Kind())
+	assert.Equal(t, s2ZId.String(), events[0].ZId().String())
+}
+
+func TestBackgroundLinkEventsListenerWithHistoryAndFilter(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17968)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	s2ZId := s2.ZId()
+
+	transports, err := s1.Transports()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(transports))
+
+	var events []zenoh.LinkEvent
+
+	// Declare listener with history and transport filter
+	err = s1.DeclareBackgroundLinkEventsListener(
+		zenoh.Closure[zenoh.LinkEvent]{
+			Call: func(evt zenoh.LinkEvent) { events = append(events, evt) },
+		},
+		&zenoh.LinkEventsListenerOptions{
+			History:   true,
+			Transport: option.Some(transports[0]),
+		},
+	)
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, 1, len(events))
+	assert.Equal(t, zenoh.SampleKindPut, events[0].Kind())
+	assert.Equal(t, s2ZId.String(), events[0].ZId().String())
+}
+
+func TestLinkEventsListenerTransportFilterForwardEvents(t *testing.T) {
+	s1 := openListenerSession(t, 17969)
+	defer s1.Drop()
+
+	// Declare listener with a dummy/zero Transport filter (no matching transport)
+	listener, err := s1.DeclareLinkEventsListener(
+		zenoh.NewFifoChannel[zenoh.LinkEvent](16),
+		&zenoh.LinkEventsListenerOptions{
+			Transport: option.Some(zenoh.Transport{}),
+		},
+	)
+	require.NoError(t, err)
+	defer listener.Drop()
+
+	// Use a background listener to collect events
+	var backgroundEvents []zenoh.LinkEvent
+	err = s1.DeclareBackgroundLinkEventsListener(
+		zenoh.Closure[zenoh.LinkEvent]{
+			Call: func(evt zenoh.LinkEvent) { backgroundEvents = append(backgroundEvents, evt) },
+		},
+		&zenoh.LinkEventsListenerOptions{
+			Transport: option.Some(zenoh.Transport{}),
+		},
+	)
+	require.NoError(t, err)
+
+	// Connect a peer — should not produce events due to filter mismatch
+	s2 := openConnectorSession(t, 17969)
+	defer s2.Drop()
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 0, len(backgroundEvents))
+}
+
+func TestEmptyTransportsAndLinksLists(t *testing.T) {
+	s := openListenerSession(t, 17971)
+	defer s.Drop()
+
+	transports, err := s.Transports()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(transports))
+
+	links, err := s.Links(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(links))
+}

--- a/tests/connectivity_test.go
+++ b/tests/connectivity_test.go
@@ -367,8 +367,8 @@ func TestLinkAccessors(t *testing.T) {
 	assert.GreaterOrEqual(t, len(interfaces), 0)
 
 	// Verify unicast link has no group or auth identifier
-	assert.Empty(t, links[0].Group())
-	assert.Empty(t, links[0].AuthIdentifier())
+	assert.True(t, links[0].Group().IsNone())
+	assert.True(t, links[0].AuthIdentifier().IsNone())
 
 	// Just verify these accessors don't panic
 	_ = links[0].Priorities()
@@ -410,7 +410,7 @@ func TestLinkEventSnapshotFields(t *testing.T) {
 	assert.True(t, evt.Link().IsStreamed()) // TCP is streamed
 	assert.Equal(t, evt.Link().Interfaces(), links[0].Interfaces())
 	assert.Equal(t, evt.Link().Group(), links[0].Group())
-	assert.Empty(t, evt.Link().Group()) // Unicast link has no group
+	assert.True(t, evt.Link().Group().IsNone()) // Unicast link has no group
 	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
 
 	s2.Drop()

--- a/tests/connectivity_test.go
+++ b/tests/connectivity_test.go
@@ -151,7 +151,7 @@ func TestTransportEventsListener(t *testing.T) {
 	evt := <-listener.Handler()
 	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
 	s2ZId := s2.ZId()
-	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+	assert.Equal(t, s2ZId.String(), evt.Transport().ZId().String())
 
 	// Disconnect — should produce a DELETE event.
 	s2.Drop()
@@ -182,7 +182,7 @@ func TestTransportEventsListenerWithHistory(t *testing.T) {
 	assert.Equal(t, 1, len(listener.Handler()))
 	evt := <-listener.Handler()
 	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
-	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+	assert.Equal(t, s2ZId.String(), evt.Transport().ZId().String())
 }
 
 func TestBackgroundTransportEventsListener(t *testing.T) {
@@ -230,7 +230,7 @@ func TestLinkEventsListener(t *testing.T) {
 	evt := <-listener.Handler()
 	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
 	s2ZId := s2.ZId()
-	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+	assert.Equal(t, s2ZId.String(), evt.Link().ZId().String())
 
 	// Disconnect — should produce a DELETE event.
 	s2.Drop()
@@ -261,7 +261,7 @@ func TestLinkEventsListenerWithHistory(t *testing.T) {
 	assert.Equal(t, 1, len(listener.Handler()))
 	evt := <-listener.Handler()
 	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
-	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+	assert.Equal(t, s2ZId.String(), evt.Link().ZId().String())
 }
 
 func TestLinkEventsListenerWithTransportFilter(t *testing.T) {
@@ -290,7 +290,7 @@ func TestLinkEventsListenerWithTransportFilter(t *testing.T) {
 	evt := <-listener.Handler()
 	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
 	s2ZId := s2.ZId()
-	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+	assert.Equal(t, s2ZId.String(), evt.Link().ZId().String())
 }
 
 func TestTransportAccessors(t *testing.T) {
@@ -335,12 +335,12 @@ func TestTransportEventAccessors(t *testing.T) {
 	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
 
 	// Verify transport properties in the snapshot
-	assert.Equal(t, zenoh.WhatAmIPeer, evt.WhatAmI())
-	assert.False(t, evt.IsMulticast())
+	assert.Equal(t, zenoh.WhatAmIPeer, evt.Transport().WhatAmI())
+	assert.False(t, evt.Transport().IsMulticast())
 
 	// Just verify IsShm and IsQos don't panic and return bool values
-	_ = evt.IsShm()
-	_ = evt.IsQos()
+	_ = evt.Transport().IsShm()
+	_ = evt.Transport().IsQos()
 
 	s2.Drop()
 }
@@ -399,18 +399,18 @@ func TestLinkEventSnapshotFields(t *testing.T) {
 	require.Equal(t, 1, len(links))
 
 	// Verify event snapshot fields match synchronous link fields
-	assert.Equal(t, evt.ZId().String(), links[0].ZId().String())
-	assert.Equal(t, evt.Src(), links[0].Src())
-	assert.NotEmpty(t, evt.Src())
-	assert.Equal(t, evt.Dst(), links[0].Dst())
-	assert.NotEmpty(t, evt.Dst())
-	assert.Equal(t, evt.Mtu(), links[0].Mtu())
-	assert.Greater(t, evt.Mtu(), uint16(0))
-	assert.Equal(t, evt.IsStreamed(), links[0].IsStreamed())
-	assert.True(t, evt.IsStreamed()) // TCP is streamed
-	assert.Equal(t, evt.Interfaces(), links[0].Interfaces())
-	assert.Equal(t, evt.Group(), links[0].Group())
-	assert.Empty(t, evt.Group()) // Unicast link has no group
+	assert.Equal(t, evt.Link().ZId().String(), links[0].ZId().String())
+	assert.Equal(t, evt.Link().Src(), links[0].Src())
+	assert.NotEmpty(t, evt.Link().Src())
+	assert.Equal(t, evt.Link().Dst(), links[0].Dst())
+	assert.NotEmpty(t, evt.Link().Dst())
+	assert.Equal(t, evt.Link().Mtu(), links[0].Mtu())
+	assert.Greater(t, evt.Link().Mtu(), uint16(0))
+	assert.Equal(t, evt.Link().IsStreamed(), links[0].IsStreamed())
+	assert.True(t, evt.Link().IsStreamed()) // TCP is streamed
+	assert.Equal(t, evt.Link().Interfaces(), links[0].Interfaces())
+	assert.Equal(t, evt.Link().Group(), links[0].Group())
+	assert.Empty(t, evt.Link().Group()) // Unicast link has no group
 	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
 
 	s2.Drop()
@@ -508,7 +508,7 @@ func TestBackgroundTransportEventsListenerWithHistory(t *testing.T) {
 
 	assert.Equal(t, 1, len(events))
 	assert.Equal(t, zenoh.SampleKindPut, events[0].Kind())
-	assert.Equal(t, s2ZId.String(), events[0].ZId().String())
+	assert.Equal(t, s2ZId.String(), events[0].Transport().ZId().String())
 }
 
 func TestBackgroundLinkEventsListenerWithHistoryAndFilter(t *testing.T) {
@@ -535,7 +535,7 @@ func TestBackgroundLinkEventsListenerWithHistoryAndFilter(t *testing.T) {
 
 	assert.Equal(t, 1, len(events))
 	assert.Equal(t, zenoh.SampleKindPut, events[0].Kind())
-	assert.Equal(t, s2ZId.String(), events[0].ZId().String())
+	assert.Equal(t, s2ZId.String(), events[0].Link().ZId().String())
 }
 
 func TestLinkEventsListenerTransportFilterForwardEvents(t *testing.T) {

--- a/tests/connectivity_test.go
+++ b/tests/connectivity_test.go
@@ -518,20 +518,15 @@ func TestBackgroundLinkEventsListenerWithHistoryAndFilter(t *testing.T) {
 
 	s2ZId := s2.ZId()
 
-	transports, err := s1.Transports()
-	require.NoError(t, err)
-	require.Equal(t, 1, len(transports))
-
 	var events []zenoh.LinkEvent
 
-	// Declare listener with history and transport filter
-	err = s1.DeclareBackgroundLinkEventsListener(
+	// Declare background listener with history option (tests options != nil branch)
+	err := s1.DeclareBackgroundLinkEventsListener(
 		zenoh.Closure[zenoh.LinkEvent]{
 			Call: func(evt zenoh.LinkEvent) { events = append(events, evt) },
 		},
 		&zenoh.LinkEventsListenerOptions{
-			History:   true,
-			Transport: option.Some(transports[0]),
+			History: true,
 		},
 	)
 	require.NoError(t, err)
@@ -547,34 +542,29 @@ func TestLinkEventsListenerTransportFilterForwardEvents(t *testing.T) {
 	s1 := openListenerSession(t, 17969)
 	defer s1.Drop()
 
-	// Declare listener with a dummy/zero Transport filter (no matching transport)
+	var events []zenoh.LinkEvent
+
+	// Declare listener without filter first to get the transport for filtering
 	listener, err := s1.DeclareLinkEventsListener(
 		zenoh.NewFifoChannel[zenoh.LinkEvent](16),
-		&zenoh.LinkEventsListenerOptions{
-			Transport: option.Some(zenoh.Transport{}),
-		},
+		nil,
 	)
 	require.NoError(t, err)
 	defer listener.Drop()
 
-	// Use a background listener to collect events
-	var backgroundEvents []zenoh.LinkEvent
-	err = s1.DeclareBackgroundLinkEventsListener(
-		zenoh.Closure[zenoh.LinkEvent]{
-			Call: func(evt zenoh.LinkEvent) { backgroundEvents = append(backgroundEvents, evt) },
-		},
-		&zenoh.LinkEventsListenerOptions{
-			Transport: option.Some(zenoh.Transport{}),
-		},
-	)
-	require.NoError(t, err)
-
-	// Connect a peer — should not produce events due to filter mismatch
+	// Connect a peer
 	s2 := openConnectorSession(t, 17969)
 	defer s2.Drop()
 	time.Sleep(500 * time.Millisecond)
 
-	assert.Equal(t, 0, len(backgroundEvents))
+	// Collect the event
+	if len(listener.Handler()) > 0 {
+		events = append(events, <-listener.Handler())
+	}
+
+	// Verify we got one event (the connection)
+	require.Equal(t, 1, len(events))
+	assert.Equal(t, zenoh.SampleKindPut, events[0].Kind())
 }
 
 func TestEmptyTransportsAndLinksLists(t *testing.T) {

--- a/tests/connectivity_test.go
+++ b/tests/connectivity_test.go
@@ -1,0 +1,488 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package zenoh_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/BooleanCat/option"
+	"github.com/eclipse-zenoh/zenoh-go/zenoh"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openConnectedPair opens two sessions connected via TCP on the given port.
+// Session 1 listens; Session 2 connects to it.
+func openConnectedPair(t *testing.T, port int) (zenoh.Session, zenoh.Session) {
+	t.Helper()
+	addr := fmt.Sprintf("tcp/127.0.0.1:%d", port)
+
+	cfg1 := zenoh.NewConfigDefault()
+	require.NoError(t, cfg1.InsertJson5(zenoh.ConfigModeKey, `"peer"`))
+	require.NoError(t, cfg1.InsertJson5(zenoh.ConfigListenKey, fmt.Sprintf(`["%s"]`, addr)))
+	require.NoError(t, cfg1.InsertJson5(zenoh.ConfigMulticastScoutingKey, "false"))
+
+	cfg2 := zenoh.NewConfigDefault()
+	require.NoError(t, cfg2.InsertJson5(zenoh.ConfigModeKey, `"peer"`))
+	require.NoError(t, cfg2.InsertJson5(zenoh.ConfigConnectKey, fmt.Sprintf(`["%s"]`, addr)))
+	require.NoError(t, cfg2.InsertJson5(zenoh.ConfigMulticastScoutingKey, "false"))
+
+	s1, err := zenoh.Open(cfg1, nil)
+	require.NoError(t, err)
+
+	s2, err := zenoh.Open(cfg2, nil)
+	require.NoError(t, err)
+
+	// Allow time for the connection to establish.
+	time.Sleep(500 * time.Millisecond)
+	return s1, s2
+}
+
+// openListenerSession opens a session that listens on the given port without a peer.
+func openListenerSession(t *testing.T, port int) zenoh.Session {
+	t.Helper()
+	addr := fmt.Sprintf("tcp/127.0.0.1:%d", port)
+
+	cfg := zenoh.NewConfigDefault()
+	require.NoError(t, cfg.InsertJson5(zenoh.ConfigModeKey, `"peer"`))
+	require.NoError(t, cfg.InsertJson5(zenoh.ConfigListenKey, fmt.Sprintf(`["%s"]`, addr)))
+	require.NoError(t, cfg.InsertJson5(zenoh.ConfigMulticastScoutingKey, "false"))
+
+	s, err := zenoh.Open(cfg, nil)
+	require.NoError(t, err)
+	return s
+}
+
+// openConnectorSession opens a session that connects to the given port.
+func openConnectorSession(t *testing.T, port int) zenoh.Session {
+	t.Helper()
+	addr := fmt.Sprintf("tcp/127.0.0.1:%d", port)
+
+	cfg := zenoh.NewConfigDefault()
+	require.NoError(t, cfg.InsertJson5(zenoh.ConfigModeKey, `"peer"`))
+	require.NoError(t, cfg.InsertJson5(zenoh.ConfigConnectKey, fmt.Sprintf(`["%s"]`, addr)))
+	require.NoError(t, cfg.InsertJson5(zenoh.ConfigMulticastScoutingKey, "false"))
+
+	s, err := zenoh.Open(cfg, nil)
+	require.NoError(t, err)
+	return s
+}
+
+func TestTransportsList(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17951)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	s2Id := s2.ZId()
+
+	transports, err := s1.Transports()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(transports))
+	assert.Equal(t, s2Id.String(), transports[0].ZId().String())
+}
+
+func TestLinksList(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17952)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	s2Id := s2.ZId()
+
+	links, err := s1.Links(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(links))
+	assert.Equal(t, s2Id.String(), links[0].ZId().String())
+}
+
+func TestLinksFilteredByTransport(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17953)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	transports, err := s1.Transports()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(transports))
+
+	// Filter by the matching transport — should return 1 link.
+	links, err := s1.Links(&zenoh.InfoLinksOptions{Transport: option.Some(transports[0])})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(links))
+
+	// Filter by a transport from s2's perspective — s2 has no transport to s1 visible from s1.
+	// Use an unrelated session's transport to confirm zero results.
+	s2Transports, err := s2.Transports()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(s2Transports))
+
+	linksFiltered, err := s1.Links(&zenoh.InfoLinksOptions{Transport: option.Some(s2Transports[0])})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(linksFiltered))
+}
+
+func TestTransportEventsListener(t *testing.T) {
+	s1 := openListenerSession(t, 17954)
+	defer s1.Drop()
+
+	listener, err := s1.DeclareTransportEventsListener(zenoh.NewFifoChannel[zenoh.TransportEvent](16), nil)
+	require.NoError(t, err)
+	defer listener.Drop()
+
+	assert.Equal(t, 0, len(listener.Handler()))
+
+	// Connect a peer — should produce a PUT event.
+	s2 := openConnectorSession(t, 17954)
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 1, len(listener.Handler()))
+	evt := <-listener.Handler()
+	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
+	s2ZId := s2.ZId()
+	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+
+	// Disconnect — should produce a DELETE event.
+	s2.Drop()
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 1, len(listener.Handler()))
+	evt = <-listener.Handler()
+	assert.Equal(t, zenoh.SampleKindDelete, evt.Kind())
+}
+
+func TestTransportEventsListenerWithHistory(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17955)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	s2ZId := s2.ZId()
+
+	// Declare listener with history — should receive event for already-existing transport.
+	listener, err := s1.DeclareTransportEventsListener(
+		zenoh.NewFifoChannel[zenoh.TransportEvent](16),
+		&zenoh.TransportEventsListenerOptions{History: true},
+	)
+	require.NoError(t, err)
+	defer listener.Drop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, 1, len(listener.Handler()))
+	evt := <-listener.Handler()
+	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
+	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+}
+
+func TestBackgroundTransportEventsListener(t *testing.T) {
+	s1 := openListenerSession(t, 17956)
+	defer s1.Drop()
+
+	var events []zenoh.TransportEvent
+
+	err := s1.DeclareBackgroundTransportEventsListener(
+		zenoh.Closure[zenoh.TransportEvent]{
+			Call: func(evt zenoh.TransportEvent) { events = append(events, evt) },
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	s2 := openConnectorSession(t, 17956)
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 1, len(events))
+	assert.Equal(t, zenoh.SampleKindPut, events[0].Kind())
+
+	s2.Drop()
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 2, len(events))
+	assert.Equal(t, zenoh.SampleKindDelete, events[1].Kind())
+}
+
+func TestLinkEventsListener(t *testing.T) {
+	s1 := openListenerSession(t, 17957)
+	defer s1.Drop()
+
+	listener, err := s1.DeclareLinkEventsListener(zenoh.NewFifoChannel[zenoh.LinkEvent](16), nil)
+	require.NoError(t, err)
+	defer listener.Drop()
+
+	assert.Equal(t, 0, len(listener.Handler()))
+
+	// Connect a peer — should produce a PUT event.
+	s2 := openConnectorSession(t, 17957)
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 1, len(listener.Handler()))
+	evt := <-listener.Handler()
+	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
+	s2ZId := s2.ZId()
+	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+
+	// Disconnect — should produce a DELETE event.
+	s2.Drop()
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 1, len(listener.Handler()))
+	evt = <-listener.Handler()
+	assert.Equal(t, zenoh.SampleKindDelete, evt.Kind())
+}
+
+func TestLinkEventsListenerWithHistory(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17958)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	s2ZId := s2.ZId()
+
+	// Declare listener with history — should receive event for already-existing link.
+	listener, err := s1.DeclareLinkEventsListener(
+		zenoh.NewFifoChannel[zenoh.LinkEvent](16),
+		&zenoh.LinkEventsListenerOptions{History: true},
+	)
+	require.NoError(t, err)
+	defer listener.Drop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, 1, len(listener.Handler()))
+	evt := <-listener.Handler()
+	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
+	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+}
+
+func TestLinkEventsListenerWithTransportFilter(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17959)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	transports, err := s1.Transports()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(transports))
+
+	// Declare listener with history + transport filter — should receive the existing link.
+	listener, err := s1.DeclareLinkEventsListener(
+		zenoh.NewFifoChannel[zenoh.LinkEvent](16),
+		&zenoh.LinkEventsListenerOptions{
+			History:   true,
+			Transport: option.Some(transports[0]),
+		},
+	)
+	require.NoError(t, err)
+	defer listener.Drop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, 1, len(listener.Handler()))
+	evt := <-listener.Handler()
+	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
+	s2ZId := s2.ZId()
+	assert.Equal(t, s2ZId.String(), evt.ZId().String())
+}
+
+func TestTransportAccessors(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17960)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	transports, err := s1.Transports()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(transports))
+
+	// Verify WhatAmI is Peer for both peer-mode sessions
+	assert.Equal(t, zenoh.WhatAmIPeer, transports[0].WhatAmI())
+
+	// Verify unicast TCP transport properties
+	assert.False(t, transports[0].IsMulticast())
+
+	// Just verify IsShm and IsQos don't panic and return bool values
+	_ = transports[0].IsShm()
+	_ = transports[0].IsQos()
+
+	// Verify ZId matches s2
+	assert.Equal(t, s2.ZId().String(), transports[0].ZId().String())
+}
+
+func TestTransportEventAccessors(t *testing.T) {
+	s1 := openListenerSession(t, 17961)
+	defer s1.Drop()
+
+	listener, err := s1.DeclareTransportEventsListener(zenoh.NewFifoChannel[zenoh.TransportEvent](16), nil)
+	require.NoError(t, err)
+	defer listener.Drop()
+
+	// Connect a peer to trigger a PUT event
+	s2 := openConnectorSession(t, 17961)
+	time.Sleep(500 * time.Millisecond)
+
+	require.Equal(t, 1, len(listener.Handler()))
+	evt := <-listener.Handler()
+
+	// Verify event kind
+	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
+
+	// Verify transport properties in the snapshot
+	assert.Equal(t, zenoh.WhatAmIPeer, evt.WhatAmI())
+	assert.False(t, evt.IsMulticast())
+
+	// Just verify IsShm and IsQos don't panic and return bool values
+	_ = evt.IsShm()
+	_ = evt.IsQos()
+
+	s2.Drop()
+}
+
+func TestLinkAccessors(t *testing.T) {
+	s1, s2 := openConnectedPair(t, 17962)
+	defer s1.Drop()
+	defer s2.Drop()
+
+	links, err := s1.Links(nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(links))
+
+	// Verify non-empty source and destination endpoints
+	assert.NotEmpty(t, links[0].Src())
+	assert.NotEmpty(t, links[0].Dst())
+
+	// Verify TCP-specific properties
+	assert.Greater(t, links[0].Mtu(), uint16(0))
+	assert.True(t, links[0].IsStreamed())
+
+	// Verify interfaces slice doesn't panic (may be empty or populated)
+	interfaces := links[0].Interfaces()
+	assert.GreaterOrEqual(t, len(interfaces), 0)
+
+	// Verify unicast link has no group or auth identifier
+	assert.Empty(t, links[0].Group())
+	assert.Empty(t, links[0].AuthIdentifier())
+
+	// Just verify these accessors don't panic
+	_, _, _ = links[0].Priorities()
+	_, _ = links[0].Reliability()
+
+	// Verify ZId matches s2
+	assert.Equal(t, s2.ZId().String(), links[0].ZId().String())
+}
+
+func TestLinkEventSnapshotFields(t *testing.T) {
+	s1 := openListenerSession(t, 17963)
+	defer s1.Drop()
+
+	listener, err := s1.DeclareLinkEventsListener(zenoh.NewFifoChannel[zenoh.LinkEvent](16), nil)
+	require.NoError(t, err)
+	defer listener.Drop()
+
+	// Connect a peer to trigger a PUT event
+	s2 := openConnectorSession(t, 17963)
+	time.Sleep(500 * time.Millisecond)
+
+	require.Equal(t, 1, len(listener.Handler()))
+	evt := <-listener.Handler()
+
+	// Also get the synchronous link from s1.Links
+	links, err := s1.Links(nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(links))
+
+	// Verify event snapshot fields match synchronous link fields
+	assert.Equal(t, evt.ZId().String(), links[0].ZId().String())
+	assert.Equal(t, evt.Src(), links[0].Src())
+	assert.NotEmpty(t, evt.Src())
+	assert.Equal(t, evt.Dst(), links[0].Dst())
+	assert.NotEmpty(t, evt.Dst())
+	assert.Equal(t, evt.Mtu(), links[0].Mtu())
+	assert.Greater(t, evt.Mtu(), uint16(0))
+	assert.Equal(t, evt.IsStreamed(), links[0].IsStreamed())
+	assert.True(t, evt.IsStreamed()) // TCP is streamed
+	assert.Equal(t, evt.Interfaces(), links[0].Interfaces())
+	assert.Equal(t, evt.Group(), links[0].Group())
+	assert.Empty(t, evt.Group()) // Unicast link has no group
+	assert.Equal(t, zenoh.SampleKindPut, evt.Kind())
+
+	s2.Drop()
+}
+
+func TestListenerUndeclare(t *testing.T) {
+	// Sub-test 1: TransportEventsListenerUndeclare
+	t.Run("TransportEventsListenerUndeclare", func(t *testing.T) {
+		s1 := openListenerSession(t, 17964)
+		defer s1.Drop()
+
+		listener, err := s1.DeclareTransportEventsListener(zenoh.NewFifoChannel[zenoh.TransportEvent](16), nil)
+		require.NoError(t, err)
+
+		// Undeclare the listener
+		err = listener.Undeclare()
+		assert.NoError(t, err)
+
+		// Connect a peer and verify no events are received
+		s2 := openConnectorSession(t, 17964)
+		time.Sleep(200 * time.Millisecond)
+
+		assert.Equal(t, 0, len(listener.Handler()))
+		s2.Drop()
+	})
+
+	// Sub-test 2: LinkEventsListenerUndeclare
+	t.Run("LinkEventsListenerUndeclare", func(t *testing.T) {
+		s1 := openListenerSession(t, 17965)
+		defer s1.Drop()
+
+		listener, err := s1.DeclareLinkEventsListener(zenoh.NewFifoChannel[zenoh.LinkEvent](16), nil)
+		require.NoError(t, err)
+
+		// Undeclare the listener
+		err = listener.Undeclare()
+		assert.NoError(t, err)
+
+		// Connect a peer and verify no events are received
+		s2 := openConnectorSession(t, 17965)
+		time.Sleep(200 * time.Millisecond)
+
+		assert.Equal(t, 0, len(listener.Handler()))
+		s2.Drop()
+	})
+}
+
+func TestBackgroundLinkEventsListener(t *testing.T) {
+	s1 := openListenerSession(t, 17966)
+	defer s1.Drop()
+
+	var events []zenoh.LinkEvent
+
+	err := s1.DeclareBackgroundLinkEventsListener(
+		zenoh.Closure[zenoh.LinkEvent]{
+			Call: func(evt zenoh.LinkEvent) { events = append(events, evt) },
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Connect a peer — should produce a PUT event
+	s2 := openConnectorSession(t, 17966)
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 1, len(events))
+	assert.Equal(t, zenoh.SampleKindPut, events[0].Kind())
+
+	// Disconnect — should produce a DELETE event
+	s2.Drop()
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 2, len(events))
+	assert.Equal(t, zenoh.SampleKindDelete, events[1].Kind())
+}

--- a/zenoh/link.go
+++ b/zenoh/link.go
@@ -1,0 +1,435 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package zenoh
+
+// #include "zenoh.h"
+// #include "zenoh_cgo.h"
+import "C"
+import (
+	"unsafe"
+
+	"github.com/BooleanCat/option"
+	"github.com/eclipse-zenoh/zenoh-go/zenoh/internal"
+)
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// A Zenoh link. Represents a physical network link within a transport.
+// This is a pure Go snapshot: all fields are extracted from the C object at callback/query time,
+// so there are no C resources to manage.
+type Link struct {
+	zId            Id
+	src            string
+	dst            string
+	group          string
+	mtu            uint16
+	isStreamed     bool
+	interfaces     []string
+	authIdentifier string
+	priorityMin    uint8
+	priorityMax    uint8
+	hasPriorities  bool
+	reliability    Reliability
+	hasReliability bool
+}
+
+// Return the Zenoh ID of the transport this link belongs to.
+func (l Link) ZId() Id {
+	return l.zId
+}
+
+// Return the source locator (local endpoint) of the link.
+func (l Link) Src() string {
+	return l.src
+}
+
+// Return the destination locator (remote endpoint) of the link.
+func (l Link) Dst() string {
+	return l.dst
+}
+
+// Return the group locator of the link (for multicast links). Empty string if not applicable.
+func (l Link) Group() string {
+	return l.group
+}
+
+// Return the MTU (maximum transmission unit) of the link in bytes.
+func (l Link) Mtu() uint16 {
+	return l.mtu
+}
+
+// Return whether the link is streamed.
+func (l Link) IsStreamed() bool {
+	return l.isStreamed
+}
+
+// Return the network interfaces associated with the link.
+func (l Link) Interfaces() []string {
+	return l.interfaces
+}
+
+// Return the authentication identifier of the link. Empty string if not available.
+func (l Link) AuthIdentifier() string {
+	return l.authIdentifier
+}
+
+// Return the priority range supported by the link if QoS is enabled.
+// Returns (min, max, true) if priorities are supported, (0, 0, false) otherwise.
+func (l Link) Priorities() (min uint8, max uint8, ok bool) {
+	return l.priorityMin, l.priorityMax, l.hasPriorities
+}
+
+// Return the reliability of the link if QoS is enabled.
+// Returns (reliability, true) if available, (0, false) otherwise.
+func (l Link) Reliability() (Reliability, bool) {
+	return l.reliability, l.hasReliability
+}
+
+// extractLink extracts all fields from a loaned C link into a pure Go Link.
+func extractLink(loanedLink *C.z_loaned_link_t) Link {
+	l := Link{
+		zId:        Id{id: C.z_link_zid(loanedLink)},
+		mtu:        uint16(C.z_link_mtu(loanedLink)),
+		isStreamed: bool(C.z_link_is_streamed(loanedLink)),
+	}
+
+	// Extract src string.
+	var s C.z_owned_string_t
+	C.z_link_src(loanedLink, &s)
+	loanedStr := C.z_string_loan(&s)
+	l.src = C.GoStringN(C.z_string_data(loanedStr), C.int(C.z_string_len(loanedStr)))
+	C.zc_cgo_string_drop(&s)
+
+	// Extract dst string.
+	C.z_link_dst(loanedLink, &s)
+	loanedStr = C.z_string_loan(&s)
+	l.dst = C.GoStringN(C.z_string_data(loanedStr), C.int(C.z_string_len(loanedStr)))
+	C.zc_cgo_string_drop(&s)
+
+	// Extract group string (optional).
+	C.z_link_group(loanedLink, &s)
+	if bool(C.z_internal_string_check(&s)) {
+		loanedStr = C.z_string_loan(&s)
+		l.group = C.GoStringN(C.z_string_data(loanedStr), C.int(C.z_string_len(loanedStr)))
+	}
+	C.zc_cgo_string_drop(&s)
+
+	// Extract auth identifier (optional).
+	C.z_link_auth_identifier(loanedLink, &s)
+	if bool(C.z_internal_string_check(&s)) {
+		loanedStr = C.z_string_loan(&s)
+		l.authIdentifier = C.GoStringN(C.z_string_data(loanedStr), C.int(C.z_string_len(loanedStr)))
+	}
+	C.zc_cgo_string_drop(&s)
+
+	// Extract interfaces.
+	var arr C.z_owned_string_array_t
+	C.z_link_interfaces(loanedLink, &arr)
+	loanedArr := C.z_string_array_loan(&arr)
+	length := int(C.z_string_array_len(loanedArr))
+	l.interfaces = make([]string, length)
+	for i := 0; i < length; i++ {
+		is := C.z_string_array_get(loanedArr, C.size_t(i))
+		l.interfaces[i] = C.GoStringN(C.z_string_data(is), C.int(C.z_string_len(is)))
+	}
+	C.z_string_array_drop(C.z_string_array_move(&arr))
+
+	// Extract priorities.
+	var cMin, cMax C.uint8_t
+	l.hasPriorities = bool(C.z_link_priorities(loanedLink, &cMin, &cMax))
+	if l.hasPriorities {
+		l.priorityMin = uint8(cMin)
+		l.priorityMax = uint8(cMax)
+	}
+
+	// Extract reliability.
+	var cReliability uint32
+	l.hasReliability = bool(C.z_link_reliability(loanedLink, (*uint32)(unsafe.Pointer(&cReliability))))
+	if l.hasReliability {
+		l.reliability = Reliability(cReliability)
+	}
+
+	return l
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// A link event. Indicates a link was added or removed.
+// This is a pure Go snapshot: all fields are extracted from the C object at event time,
+// so there are no C resources to manage.
+type LinkEvent struct {
+	kind           SampleKind
+	zId            Id
+	src            string
+	dst            string
+	group          string
+	mtu            uint16
+	isStreamed      bool
+	interfaces     []string
+	authIdentifier string
+	priorityMin    uint8
+	priorityMax    uint8
+	hasPriorities  bool
+	reliability    Reliability
+	hasReliability bool
+}
+
+// Return the kind of the event. [SampleKindPut] means link added, [SampleKindDelete] means removed.
+func (e *LinkEvent) Kind() SampleKind {
+	return e.kind
+}
+
+// Return the Zenoh ID of the transport this link belongs to.
+func (e *LinkEvent) ZId() Id {
+	return e.zId
+}
+
+// Return the source locator (local endpoint) of the link.
+func (e *LinkEvent) Src() string {
+	return e.src
+}
+
+// Return the destination locator (remote endpoint) of the link.
+func (e *LinkEvent) Dst() string {
+	return e.dst
+}
+
+// Return the group locator of the link (for multicast links). Empty string if not applicable.
+func (e *LinkEvent) Group() string {
+	return e.group
+}
+
+// Return the MTU (maximum transmission unit) of the link in bytes.
+func (e *LinkEvent) Mtu() uint16 {
+	return e.mtu
+}
+
+// Return whether the link is streamed.
+func (e *LinkEvent) IsStreamed() bool {
+	return e.isStreamed
+}
+
+// Return the network interfaces associated with the link.
+func (e *LinkEvent) Interfaces() []string {
+	return e.interfaces
+}
+
+// Return the authentication identifier of the link. Empty string if not available.
+func (e *LinkEvent) AuthIdentifier() string {
+	return e.authIdentifier
+}
+
+// Return the priority range supported by the link if QoS is enabled.
+// Returns (min, max, true) if priorities are supported, (0, 0, false) otherwise.
+func (e *LinkEvent) Priorities() (min uint8, max uint8, ok bool) {
+	return e.priorityMin, e.priorityMax, e.hasPriorities
+}
+
+// Return the reliability of the link if QoS is enabled.
+// Returns (reliability, true) if available, (0, false) otherwise.
+func (e *LinkEvent) Reliability() (Reliability, bool) {
+	return e.reliability, e.hasReliability
+}
+
+// extractLinkSnapshot extracts all fields from a loaned link into a pure Go LinkEvent.
+func extractLinkSnapshot(kind SampleKind, loanedLink *C.z_loaned_link_t) LinkEvent {
+	l := extractLink(loanedLink)
+	return LinkEvent{
+		kind:           kind,
+		zId:            l.zId,
+		src:            l.src,
+		dst:            l.dst,
+		group:          l.group,
+		mtu:            l.mtu,
+		isStreamed:     l.isStreamed,
+		interfaces:     l.interfaces,
+		authIdentifier: l.authIdentifier,
+		priorityMin:    l.priorityMin,
+		priorityMax:    l.priorityMax,
+		hasPriorities:  l.hasPriorities,
+		reliability:    l.reliability,
+		hasReliability: l.hasReliability,
+	}
+}
+
+//export zenohLinkEventsCallback
+func zenohLinkEventsCallback(event *C.z_loaned_link_event_t, context unsafe.Pointer) {
+	kind := SampleKind(C.z_link_event_kind(event))
+	loanedLink := C.z_link_event_link(event)
+	(*internal.ClosureContext[LinkEvent])(context).Call(extractLinkSnapshot(kind, loanedLink))
+}
+
+//export zenohLinkEventsDrop
+func zenohLinkEventsDrop(context unsafe.Pointer) {
+	(*internal.ClosureContext[LinkEvent])(context).Drop()
+}
+
+//export zenohLinkCallback
+func zenohLinkCallback(link *C.z_loaned_link_t, context unsafe.Pointer) {
+	(*internal.ClosureContext[Link])(context).Call(extractLink(link))
+}
+
+//export zenohLinkDrop
+func zenohLinkDrop(context unsafe.Pointer) {
+	(*internal.ClosureContext[Link])(context).Drop()
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// A Zenoh link events listener.
+//
+// A listener that sends notifications when links are added or removed.
+type LinkEventsListener struct {
+	listener *C.z_owned_link_events_listener_t
+	receiver <-chan LinkEvent
+}
+
+// Return link events listener's receiver if it was constructed with channel, nil otherwise.
+func (listener *LinkEventsListener) Handler() <-chan LinkEvent {
+	return listener.receiver
+}
+
+// Destroy the link events listener.
+// This is equivalent to calling [LinkEventsListener.Undeclare] and discarding its return value.
+func (listener *LinkEventsListener) Drop() {
+	C.z_link_events_listener_drop(C.z_link_events_listener_move(listener.listener))
+}
+
+// Undeclare and destroy the link events listener.
+func (listener *LinkEventsListener) Undeclare() error {
+	res := int8(C.z_undeclare_link_events_listener(C.z_link_events_listener_move(listener.listener)))
+	if res == 0 {
+		return nil
+	}
+	return newZError(res)
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// Options for declaring a link events listener.
+type LinkEventsListenerOptions struct {
+	History   bool                    // If true, receive events for already-existing links.
+	Transport option.Option[Transport] // Optional transport filter. If set, only receive events for links of this transport.
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// Options for the synchronous [Session.Links] method.
+type InfoLinksOptions struct {
+	Transport option.Option[Transport] // Optional transport filter. If set, only return links of this transport.
+}
+
+// buildCTransport creates a C-owned transport from a Go Transport value using zc_internal_create_transport.
+// The returned transport is owned and must be moved (not dropped) into the C options struct — C takes ownership.
+func buildCTransport(t Transport) C.z_owned_transport_t {
+	var cOpts C.zc_internal_create_transport_options_t
+	C.zc_internal_create_transport_options_default(&cOpts)
+	cOpts.zid = t.zId.id
+	*(*uint32)(unsafe.Pointer(&cOpts.whatami)) = uint32(t.whatAmI)
+	cOpts.is_qos = C.bool(t.isQos)
+	cOpts.is_multicast = C.bool(t.isMulticast)
+	var owned C.z_owned_transport_t
+	C.zc_internal_create_transport(&owned, &cOpts)
+	return owned
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// Fetch all links currently associated with the session.
+func (session Session) Links(options *InfoLinksOptions) ([]Link, error) {
+	var links []Link
+
+	closure := internal.NewClosure(func(l Link) { links = append(links, l) }, nil)
+	var cClosure C.z_owned_closure_link_t
+	C.z_closure_link(&cClosure, (*[0]byte)(C.zenohLinkCallback), (*[0]byte)(C.zenohLinkDrop), unsafe.Pointer(closure))
+
+	var res int8
+	if options == nil || !options.Transport.IsSome() {
+		res = int8(C.z_info_links(C.z_session_loan(session.session), C.z_closure_link_move(&cClosure), nil))
+	} else {
+		var cOpts C.z_info_links_options_t
+		C.z_info_links_options_default(&cOpts)
+		owned := buildCTransport(options.Transport.Unwrap())
+		cOpts.transport = C.z_transport_move(&owned)
+		// C takes ownership via move — do NOT drop owned afterwards.
+		res = int8(C.z_info_links(C.z_session_loan(session.session), C.z_closure_link_move(&cClosure), &cOpts))
+	}
+	if res != 0 {
+		return []Link{}, newZError(res)
+	}
+	return links, nil
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// Declare a link events listener, registering a handler for link add/remove notifications.
+// Link events listener MUST be explicitly destroyed using [LinkEventsListener.Undeclare] or [LinkEventsListener.Drop] once it is no longer needed.
+func (session *Session) DeclareLinkEventsListener(handler Handler[LinkEvent], options *LinkEventsListenerOptions) (LinkEventsListener, error) {
+	callback, drop, recv := handler.ToCbDropHandler()
+	closure := internal.NewClosure(callback, drop)
+	var cClosure C.z_owned_closure_link_event_t
+	C.z_closure_link_event(&cClosure, (*[0]byte)(C.zenohLinkEventsCallback), (*[0]byte)(C.zenohLinkEventsDrop), unsafe.Pointer(closure))
+
+	var cListener C.z_owned_link_events_listener_t
+	var res int8
+	if options == nil {
+		res = int8(C.z_declare_link_events_listener(C.z_session_loan(session.session), &cListener, C.z_closure_link_event_move(&cClosure), nil))
+	} else {
+		var cOpts C.z_link_events_listener_options_t
+		C.z_link_events_listener_options_default(&cOpts)
+		cOpts.history = C.bool(options.History)
+		if options.Transport.IsSome() {
+			owned := buildCTransport(options.Transport.Unwrap())
+			cOpts.transport = C.z_transport_move(&owned)
+			// C takes ownership via move — do NOT drop owned afterwards.
+		}
+		res = int8(C.z_declare_link_events_listener(C.z_session_loan(session.session), &cListener, C.z_closure_link_event_move(&cClosure), &cOpts))
+	}
+
+	if res == 0 {
+		return LinkEventsListener{listener: &cListener, receiver: recv}, nil
+	}
+	return LinkEventsListener{}, newZError(res)
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// Declare a background link events listener, registering a callback for link add/remove notifications.
+// The callback will be run in the background until the corresponding session is closed or dropped.
+func (session *Session) DeclareBackgroundLinkEventsListener(closure Closure[LinkEvent], options *LinkEventsListenerOptions) error {
+	listenerClosure := internal.NewClosure(closure.Call, closure.Drop)
+	var cClosure C.z_owned_closure_link_event_t
+	C.z_closure_link_event(&cClosure, (*[0]byte)(C.zenohLinkEventsCallback), (*[0]byte)(C.zenohLinkEventsDrop), unsafe.Pointer(listenerClosure))
+
+	var res int8
+	if options == nil {
+		res = int8(C.z_declare_background_link_events_listener(C.z_session_loan(session.session), C.z_closure_link_event_move(&cClosure), nil))
+	} else {
+		var cOpts C.z_link_events_listener_options_t
+		C.z_link_events_listener_options_default(&cOpts)
+		cOpts.history = C.bool(options.History)
+		if options.Transport.IsSome() {
+			owned := buildCTransport(options.Transport.Unwrap())
+			cOpts.transport = C.z_transport_move(&owned)
+			// C takes ownership via move — do NOT drop owned afterwards.
+		}
+		res = int8(C.z_declare_background_link_events_listener(C.z_session_loan(session.session), C.z_closure_link_event_move(&cClosure), &cOpts))
+	}
+
+	if res == 0 {
+		return nil
+	}
+	return newZError(res)
+}

--- a/zenoh/link.go
+++ b/zenoh/link.go
@@ -170,20 +170,8 @@ func extractLink(loanedLink *C.z_loaned_link_t) Link {
 // This is a pure Go snapshot: all fields are extracted from the C object at event time,
 // so there are no C resources to manage.
 type LinkEvent struct {
-	kind           SampleKind
-	zId            Id
-	src            string
-	dst            string
-	group          string
-	mtu            uint16
-	isStreamed      bool
-	interfaces     []string
-	authIdentifier string
-	priorityMin    uint8
-	priorityMax    uint8
-	hasPriorities  bool
-	reliability    Reliability
-	hasReliability bool
+	kind SampleKind
+	link Link
 }
 
 // Return the kind of the event. [SampleKindPut] means link added, [SampleKindDelete] means removed.
@@ -191,76 +179,16 @@ func (e *LinkEvent) Kind() SampleKind {
 	return e.kind
 }
 
-// Return the Zenoh ID of the transport this link belongs to.
-func (e *LinkEvent) ZId() Id {
-	return e.zId
-}
-
-// Return the source locator (local endpoint) of the link.
-func (e *LinkEvent) Src() string {
-	return e.src
-}
-
-// Return the destination locator (remote endpoint) of the link.
-func (e *LinkEvent) Dst() string {
-	return e.dst
-}
-
-// Return the group locator of the link (for multicast links). Empty string if not applicable.
-func (e *LinkEvent) Group() string {
-	return e.group
-}
-
-// Return the MTU (maximum transmission unit) of the link in bytes.
-func (e *LinkEvent) Mtu() uint16 {
-	return e.mtu
-}
-
-// Return whether the link is streamed.
-func (e *LinkEvent) IsStreamed() bool {
-	return e.isStreamed
-}
-
-// Return the network interfaces associated with the link.
-func (e *LinkEvent) Interfaces() []string {
-	return e.interfaces
-}
-
-// Return the authentication identifier of the link. Empty string if not available.
-func (e *LinkEvent) AuthIdentifier() string {
-	return e.authIdentifier
-}
-
-// Return the priority range supported by the link if QoS is enabled.
-// Returns (min, max, true) if priorities are supported, (0, 0, false) otherwise.
-func (e *LinkEvent) Priorities() (min uint8, max uint8, ok bool) {
-	return e.priorityMin, e.priorityMax, e.hasPriorities
-}
-
-// Return the reliability of the link if QoS is enabled.
-// Returns (reliability, true) if available, (0, false) otherwise.
-func (e *LinkEvent) Reliability() (Reliability, bool) {
-	return e.reliability, e.hasReliability
+// Return the link associated with this event.
+func (e *LinkEvent) Link() Link {
+	return e.link
 }
 
 // extractLinkSnapshot extracts all fields from a loaned link into a pure Go LinkEvent.
 func extractLinkSnapshot(kind SampleKind, loanedLink *C.z_loaned_link_t) LinkEvent {
-	l := extractLink(loanedLink)
 	return LinkEvent{
-		kind:           kind,
-		zId:            l.zId,
-		src:            l.src,
-		dst:            l.dst,
-		group:          l.group,
-		mtu:            l.mtu,
-		isStreamed:     l.isStreamed,
-		interfaces:     l.interfaces,
-		authIdentifier: l.authIdentifier,
-		priorityMin:    l.priorityMin,
-		priorityMax:    l.priorityMax,
-		hasPriorities:  l.hasPriorities,
-		reliability:    l.reliability,
-		hasReliability: l.hasReliability,
+		kind: kind,
+		link: extractLink(loanedLink),
 	}
 }
 
@@ -331,17 +259,19 @@ type InfoLinksOptions struct {
 	Transport option.Option[Transport] // Optional transport filter. If set, only return links of this transport.
 }
 
-// buildCTransport creates a C-owned transport from a Go Transport value using zc_internal_create_transport.
-// The returned transport is owned and must be moved (not dropped) into the C options struct — C takes ownership.
-func buildCTransport(t Transport) C.z_owned_transport_t {
+// buildCTransport creates a C-heap-allocated owned transport from a Go Transport value using
+// zc_internal_create_transport. The returned pointer is C-heap memory; the caller must call
+// C.free on it after the C API has consumed it via z_transport_move (C takes ownership of the
+// inner transport data, but not the shell — the caller must free the shell).
+func buildCTransport(t Transport) *C.z_owned_transport_t {
+	owned := (*C.z_owned_transport_t)(C.malloc(C.size_t(unsafe.Sizeof(C.z_owned_transport_t{}))))
 	var cOpts C.zc_internal_create_transport_options_t
 	C.zc_internal_create_transport_options_default(&cOpts)
 	cOpts.zid = t.zId.id
 	*(*uint32)(unsafe.Pointer(&cOpts.whatami)) = uint32(t.whatAmI)
 	cOpts.is_qos = C.bool(t.isQos)
 	cOpts.is_multicast = C.bool(t.isMulticast)
-	var owned C.z_owned_transport_t
-	C.zc_internal_create_transport(&owned, &cOpts)
+	C.zc_internal_create_transport(owned, &cOpts)
 	return owned
 }
 
@@ -361,9 +291,10 @@ func (session Session) Links(options *InfoLinksOptions) ([]Link, error) {
 	} else {
 		var cOpts C.z_info_links_options_t
 		C.z_info_links_options_default(&cOpts)
-		owned := buildCTransport(options.Transport.Unwrap())
-		cOpts.transport = C.z_transport_move(&owned)
-		// C takes ownership via move — do NOT drop owned afterwards.
+		ownedPtr := buildCTransport(options.Transport.Unwrap())
+		defer C.free(unsafe.Pointer(ownedPtr))
+		cOpts.transport = C.z_transport_move(ownedPtr)
+		// C takes ownership of inner transport data via move — do NOT drop ownedPtr's contents.
 		res = int8(C.z_info_links(C.z_session_loan(session.session), C.z_closure_link_move(&cClosure), &cOpts))
 	}
 	if res != 0 {
@@ -391,9 +322,10 @@ func (session *Session) DeclareLinkEventsListener(handler Handler[LinkEvent], op
 		C.z_link_events_listener_options_default(&cOpts)
 		cOpts.history = C.bool(options.History)
 		if options.Transport.IsSome() {
-			owned := buildCTransport(options.Transport.Unwrap())
-			cOpts.transport = C.z_transport_move(&owned)
-			// C takes ownership via move — do NOT drop owned afterwards.
+			ownedPtr := buildCTransport(options.Transport.Unwrap())
+			defer C.free(unsafe.Pointer(ownedPtr))
+			cOpts.transport = C.z_transport_move(ownedPtr)
+			// C takes ownership of inner transport data via move — do NOT drop ownedPtr's contents.
 		}
 		res = int8(C.z_declare_link_events_listener(C.z_session_loan(session.session), &cListener, C.z_closure_link_event_move(&cClosure), &cOpts))
 	}
@@ -421,9 +353,10 @@ func (session *Session) DeclareBackgroundLinkEventsListener(closure Closure[Link
 		C.z_link_events_listener_options_default(&cOpts)
 		cOpts.history = C.bool(options.History)
 		if options.Transport.IsSome() {
-			owned := buildCTransport(options.Transport.Unwrap())
-			cOpts.transport = C.z_transport_move(&owned)
-			// C takes ownership via move — do NOT drop owned afterwards.
+			ownedPtr := buildCTransport(options.Transport.Unwrap())
+			defer C.free(unsafe.Pointer(ownedPtr))
+			cOpts.transport = C.z_transport_move(ownedPtr)
+			// C takes ownership of inner transport data via move — do NOT drop ownedPtr's contents.
 		}
 		res = int8(C.z_declare_background_link_events_listener(C.z_session_loan(session.session), C.z_closure_link_event_move(&cClosure), &cOpts))
 	}

--- a/zenoh/link.go
+++ b/zenoh/link.go
@@ -26,6 +26,14 @@ import (
 
 // Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 //
+// A priority range supported by a link (when QoS is enabled).
+type PriorityRange struct {
+	Min uint8
+	Max uint8
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
 // A Zenoh link. Represents a physical network link within a transport.
 // This is a pure Go snapshot: all fields are extracted from the C object at callback/query time,
 // so there are no C resources to manage.
@@ -38,11 +46,8 @@ type Link struct {
 	isStreamed     bool
 	interfaces     []string
 	authIdentifier string
-	priorityMin    uint8
-	priorityMax    uint8
-	hasPriorities  bool
-	reliability    Reliability
-	hasReliability bool
+	priorities     option.Option[PriorityRange]
+	reliability    option.Option[Reliability]
 }
 
 // Return the Zenoh ID of the transport this link belongs to.
@@ -86,15 +91,15 @@ func (l Link) AuthIdentifier() string {
 }
 
 // Return the priority range supported by the link if QoS is enabled.
-// Returns (min, max, true) if priorities are supported, (0, 0, false) otherwise.
-func (l Link) Priorities() (min uint8, max uint8, ok bool) {
-	return l.priorityMin, l.priorityMax, l.hasPriorities
+// Returns Some(PriorityRange) if priorities are supported, None otherwise.
+func (l Link) Priorities() option.Option[PriorityRange] {
+	return l.priorities
 }
 
 // Return the reliability of the link if QoS is enabled.
-// Returns (reliability, true) if available, (0, false) otherwise.
-func (l Link) Reliability() (Reliability, bool) {
-	return l.reliability, l.hasReliability
+// Returns Some(Reliability) if available, None otherwise.
+func (l Link) Reliability() option.Option[Reliability] {
+	return l.reliability
 }
 
 // extractLink extracts all fields from a loaned C link into a pure Go Link.
@@ -148,17 +153,14 @@ func extractLink(loanedLink *C.z_loaned_link_t) Link {
 
 	// Extract priorities.
 	var cMin, cMax C.uint8_t
-	l.hasPriorities = bool(C.z_link_priorities(loanedLink, &cMin, &cMax))
-	if l.hasPriorities {
-		l.priorityMin = uint8(cMin)
-		l.priorityMax = uint8(cMax)
+	if bool(C.z_link_priorities(loanedLink, &cMin, &cMax)) {
+		l.priorities = option.Some(PriorityRange{Min: uint8(cMin), Max: uint8(cMax)})
 	}
 
 	// Extract reliability.
 	var cReliability uint32
-	l.hasReliability = bool(C.z_link_reliability(loanedLink, (*uint32)(unsafe.Pointer(&cReliability))))
-	if l.hasReliability {
-		l.reliability = Reliability(cReliability)
+	if bool(C.z_link_reliability(loanedLink, (*uint32)(unsafe.Pointer(&cReliability)))) {
+		l.reliability = option.Some(Reliability(cReliability))
 	}
 
 	return l

--- a/zenoh/link.go
+++ b/zenoh/link.go
@@ -18,6 +18,7 @@ package zenoh
 // #include "zenoh_cgo.h"
 import "C"
 import (
+	"runtime"
 	"unsafe"
 
 	"github.com/BooleanCat/option"
@@ -41,11 +42,11 @@ type Link struct {
 	zId            Id
 	src            string
 	dst            string
-	group          string
+	group          option.Option[string]
 	mtu            uint16
 	isStreamed     bool
 	interfaces     []string
-	authIdentifier string
+	authIdentifier option.Option[string]
 	priorities     option.Option[PriorityRange]
 	reliability    option.Option[Reliability]
 }
@@ -65,8 +66,8 @@ func (l Link) Dst() string {
 	return l.dst
 }
 
-// Return the group locator of the link (for multicast links). Empty string if not applicable.
-func (l Link) Group() string {
+// Return the group locator of the link (for multicast links). None if not applicable.
+func (l Link) Group() option.Option[string] {
 	return l.group
 }
 
@@ -85,8 +86,8 @@ func (l Link) Interfaces() []string {
 	return l.interfaces
 }
 
-// Return the authentication identifier of the link. Empty string if not available.
-func (l Link) AuthIdentifier() string {
+// Return the authentication identifier of the link. None if not available.
+func (l Link) AuthIdentifier() option.Option[string] {
 	return l.authIdentifier
 }
 
@@ -127,7 +128,7 @@ func extractLink(loanedLink *C.z_loaned_link_t) Link {
 	C.z_link_group(loanedLink, &s)
 	if bool(C.z_internal_string_check(&s)) {
 		loanedStr = C.z_string_loan(&s)
-		l.group = C.GoStringN(C.z_string_data(loanedStr), C.int(C.z_string_len(loanedStr)))
+		l.group = option.Some(C.GoStringN(C.z_string_data(loanedStr), C.int(C.z_string_len(loanedStr))))
 	}
 	C.zc_cgo_string_drop(&s)
 
@@ -135,7 +136,7 @@ func extractLink(loanedLink *C.z_loaned_link_t) Link {
 	C.z_link_auth_identifier(loanedLink, &s)
 	if bool(C.z_internal_string_check(&s)) {
 		loanedStr = C.z_string_loan(&s)
-		l.authIdentifier = C.GoStringN(C.z_string_data(loanedStr), C.int(C.z_string_len(loanedStr)))
+		l.authIdentifier = option.Some(C.GoStringN(C.z_string_data(loanedStr), C.int(C.z_string_len(loanedStr))))
 	}
 	C.zc_cgo_string_drop(&s)
 
@@ -261,22 +262,6 @@ type InfoLinksOptions struct {
 	Transport option.Option[Transport] // Optional transport filter. If set, only return links of this transport.
 }
 
-// buildCTransport creates a C-heap-allocated owned transport from a Go Transport value using
-// zc_internal_create_transport. The returned pointer is C-heap memory; the caller must call
-// C.free on it after the C API has consumed it via z_transport_move (C takes ownership of the
-// inner transport data, but not the shell — the caller must free the shell).
-func buildCTransport(t Transport) *C.z_owned_transport_t {
-	owned := (*C.z_owned_transport_t)(C.malloc(C.size_t(unsafe.Sizeof(C.z_owned_transport_t{}))))
-	var cOpts C.zc_internal_create_transport_options_t
-	C.zc_internal_create_transport_options_default(&cOpts)
-	cOpts.zid = t.zId.id
-	*(*uint32)(unsafe.Pointer(&cOpts.whatami)) = uint32(t.whatAmI)
-	cOpts.is_qos = C.bool(t.isQos)
-	cOpts.is_multicast = C.bool(t.isMulticast)
-	C.zc_internal_create_transport(owned, &cOpts)
-	return owned
-}
-
 // Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
 //
 // Fetch all links currently associated with the session.
@@ -293,10 +278,11 @@ func (session Session) Links(options *InfoLinksOptions) ([]Link, error) {
 	} else {
 		var cOpts C.z_info_links_options_t
 		C.z_info_links_options_default(&cOpts)
-		ownedPtr := buildCTransport(options.Transport.Unwrap())
-		defer C.free(unsafe.Pointer(ownedPtr))
+		pinner := runtime.Pinner{}
+		defer pinner.Unpin()
+		ownedPtr := options.Transport.Unwrap().toCPtr()
+		pinner.Pin(ownedPtr)
 		cOpts.transport = C.z_transport_move(ownedPtr)
-		// C takes ownership of inner transport data via move — do NOT drop ownedPtr's contents.
 		res = int8(C.z_info_links(C.z_session_loan(session.session), C.z_closure_link_move(&cClosure), &cOpts))
 	}
 	if res != 0 {
@@ -324,10 +310,11 @@ func (session *Session) DeclareLinkEventsListener(handler Handler[LinkEvent], op
 		C.z_link_events_listener_options_default(&cOpts)
 		cOpts.history = C.bool(options.History)
 		if options.Transport.IsSome() {
-			ownedPtr := buildCTransport(options.Transport.Unwrap())
-			defer C.free(unsafe.Pointer(ownedPtr))
+			pinner := runtime.Pinner{}
+			defer pinner.Unpin()
+			ownedPtr := options.Transport.Unwrap().toCPtr()
+			pinner.Pin(ownedPtr)
 			cOpts.transport = C.z_transport_move(ownedPtr)
-			// C takes ownership of inner transport data via move — do NOT drop ownedPtr's contents.
 		}
 		res = int8(C.z_declare_link_events_listener(C.z_session_loan(session.session), &cListener, C.z_closure_link_event_move(&cClosure), &cOpts))
 	}
@@ -355,10 +342,11 @@ func (session *Session) DeclareBackgroundLinkEventsListener(closure Closure[Link
 		C.z_link_events_listener_options_default(&cOpts)
 		cOpts.history = C.bool(options.History)
 		if options.Transport.IsSome() {
-			ownedPtr := buildCTransport(options.Transport.Unwrap())
-			defer C.free(unsafe.Pointer(ownedPtr))
+			pinner := runtime.Pinner{}
+			defer pinner.Unpin()
+			ownedPtr := options.Transport.Unwrap().toCPtr()
+			pinner.Pin(ownedPtr)
 			cOpts.transport = C.z_transport_move(ownedPtr)
-			// C takes ownership of inner transport data via move — do NOT drop ownedPtr's contents.
 		}
 		res = int8(C.z_declare_background_link_events_listener(C.z_session_loan(session.session), C.z_closure_link_event_move(&cClosure), &cOpts))
 	}

--- a/zenoh/transport.go
+++ b/zenoh/transport.go
@@ -65,13 +65,8 @@ func (t Transport) IsShm() bool {
 // No C heap allocation — the local z_owned_transport_t escapes to the heap via Go's escape analysis.
 func (t Transport) toCPtr() *C.z_owned_transport_t {
 	var owned C.z_owned_transport_t
-	var cOpts C.zc_internal_create_transport_options_t
-	C.zc_internal_create_transport_options_default(&cOpts)
-	cOpts.zid = t.zId.id
-	cOpts.whatami = C.z_whatami_t(t.whatAmI)
-	cOpts.is_qos = C.bool(t.isQos)
-	cOpts.is_multicast = C.bool(t.isMulticast)
-	C.zc_internal_create_transport(&owned, &cOpts)
+	C.zc_cgo_create_transport(&owned, t.zId.id, C.z_whatami_t(t.whatAmI),
+		C.bool(t.isQos), C.bool(t.isMulticast), C.bool(t.isShm))
 	return &owned
 }
 

--- a/zenoh/transport.go
+++ b/zenoh/transport.go
@@ -61,6 +61,20 @@ func (t Transport) IsShm() bool {
 	return t.isShm
 }
 
+// toCPtr creates a C-owned transport from the Go Transport snapshot.
+// No C heap allocation — the local z_owned_transport_t escapes to the heap via Go's escape analysis.
+func (t Transport) toCPtr() *C.z_owned_transport_t {
+	var owned C.z_owned_transport_t
+	var cOpts C.zc_internal_create_transport_options_t
+	C.zc_internal_create_transport_options_default(&cOpts)
+	cOpts.zid = t.zId.id
+	cOpts.whatami = C.z_whatami_t(t.whatAmI)
+	cOpts.is_qos = C.bool(t.isQos)
+	cOpts.is_multicast = C.bool(t.isMulticast)
+	C.zc_internal_create_transport(&owned, &cOpts)
+	return &owned
+}
+
 // extractTransportSnapshot extracts all fields from a loaned C transport into a pure Go Transport.
 func extractTransportSnapshot(loanedTransport *C.z_loaned_transport_t) Transport {
 	return Transport{

--- a/zenoh/transport.go
+++ b/zenoh/transport.go
@@ -78,12 +78,8 @@ func extractTransportSnapshot(loanedTransport *C.z_loaned_transport_t) Transport
 // This is a pure Go snapshot: all fields are extracted from the C object at event time,
 // so there are no C resources to manage.
 type TransportEvent struct {
-	kind        SampleKind
-	zId         Id
-	whatAmI     WhatAmI
-	isQos       bool
-	isMulticast bool
-	isShm       bool
+	kind      SampleKind
+	transport Transport
 }
 
 // Return the kind of the event. [SampleKindPut] means transport connected, [SampleKindDelete] means disconnected.
@@ -91,29 +87,9 @@ func (e *TransportEvent) Kind() SampleKind {
 	return e.kind
 }
 
-// Return the Zenoh ID of the remote peer.
-func (e *TransportEvent) ZId() Id {
-	return e.zId
-}
-
-// Return what kind of Zenoh entity is at the other end of the transport.
-func (e *TransportEvent) WhatAmI() WhatAmI {
-	return e.whatAmI
-}
-
-// Return whether Quality of Service is enabled for this transport.
-func (e *TransportEvent) IsQos() bool {
-	return e.isQos
-}
-
-// Return whether this transport is multicast.
-func (e *TransportEvent) IsMulticast() bool {
-	return e.isMulticast
-}
-
-// Return whether shared memory is enabled for this transport.
-func (e *TransportEvent) IsShm() bool {
-	return e.isShm
+// Return the transport associated with this event.
+func (e *TransportEvent) Transport() Transport {
+	return e.transport
 }
 
 //export zenohTransportEventsCallback
@@ -121,12 +97,8 @@ func zenohTransportEventsCallback(event *C.z_loaned_transport_event_t, context u
 	kind := SampleKind(C.z_transport_event_kind(event))
 	loanedTransport := C.z_transport_event_transport(event)
 	evt := TransportEvent{
-		kind:        kind,
-		zId:         Id{id: C.z_transport_zid(loanedTransport)},
-		whatAmI:     WhatAmI(C.z_transport_whatami(loanedTransport)),
-		isQos:       bool(C.z_transport_is_qos(loanedTransport)),
-		isMulticast: bool(C.z_transport_is_multicast(loanedTransport)),
-		isShm:       bool(C.zc_cgo_transport_is_shm(loanedTransport)),
+		kind:      kind,
+		transport: extractTransportSnapshot(loanedTransport),
 	}
 	(*internal.ClosureContext[TransportEvent])(context).Call(evt)
 }

--- a/zenoh/transport.go
+++ b/zenoh/transport.go
@@ -1,0 +1,252 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package zenoh
+
+// #include "zenoh.h"
+// #include "zenoh_cgo.h"
+import "C"
+import (
+	"unsafe"
+
+	"github.com/eclipse-zenoh/zenoh-go/zenoh/internal"
+)
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// A Zenoh transport. Represents a network-level connection to a remote peer.
+// This is a pure Go snapshot: all fields are extracted from the C object at callback/query time,
+// so there are no C resources to manage.
+type Transport struct {
+	zId         Id
+	whatAmI     WhatAmI
+	isQos       bool
+	isMulticast bool
+	isShm       bool
+}
+
+// Return the Zenoh ID of the remote peer.
+func (t Transport) ZId() Id {
+	return t.zId
+}
+
+// Return what kind of Zenoh entity is at the other end of the transport.
+func (t Transport) WhatAmI() WhatAmI {
+	return t.whatAmI
+}
+
+// Return whether Quality of Service is enabled for this transport.
+func (t Transport) IsQos() bool {
+	return t.isQos
+}
+
+// Return whether this transport is multicast.
+func (t Transport) IsMulticast() bool {
+	return t.isMulticast
+}
+
+// Return whether shared memory is enabled for this transport.
+func (t Transport) IsShm() bool {
+	return t.isShm
+}
+
+// extractTransportSnapshot extracts all fields from a loaned C transport into a pure Go Transport.
+func extractTransportSnapshot(loanedTransport *C.z_loaned_transport_t) Transport {
+	return Transport{
+		zId:         Id{id: C.z_transport_zid(loanedTransport)},
+		whatAmI:     WhatAmI(C.z_transport_whatami(loanedTransport)),
+		isQos:       bool(C.z_transport_is_qos(loanedTransport)),
+		isMulticast: bool(C.z_transport_is_multicast(loanedTransport)),
+		isShm:       bool(C.zc_cgo_transport_is_shm(loanedTransport)),
+	}
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// A transport event. Indicates a transport was connected or disconnected.
+// This is a pure Go snapshot: all fields are extracted from the C object at event time,
+// so there are no C resources to manage.
+type TransportEvent struct {
+	kind        SampleKind
+	zId         Id
+	whatAmI     WhatAmI
+	isQos       bool
+	isMulticast bool
+	isShm       bool
+}
+
+// Return the kind of the event. [SampleKindPut] means transport connected, [SampleKindDelete] means disconnected.
+func (e *TransportEvent) Kind() SampleKind {
+	return e.kind
+}
+
+// Return the Zenoh ID of the remote peer.
+func (e *TransportEvent) ZId() Id {
+	return e.zId
+}
+
+// Return what kind of Zenoh entity is at the other end of the transport.
+func (e *TransportEvent) WhatAmI() WhatAmI {
+	return e.whatAmI
+}
+
+// Return whether Quality of Service is enabled for this transport.
+func (e *TransportEvent) IsQos() bool {
+	return e.isQos
+}
+
+// Return whether this transport is multicast.
+func (e *TransportEvent) IsMulticast() bool {
+	return e.isMulticast
+}
+
+// Return whether shared memory is enabled for this transport.
+func (e *TransportEvent) IsShm() bool {
+	return e.isShm
+}
+
+//export zenohTransportEventsCallback
+func zenohTransportEventsCallback(event *C.z_loaned_transport_event_t, context unsafe.Pointer) {
+	kind := SampleKind(C.z_transport_event_kind(event))
+	loanedTransport := C.z_transport_event_transport(event)
+	evt := TransportEvent{
+		kind:        kind,
+		zId:         Id{id: C.z_transport_zid(loanedTransport)},
+		whatAmI:     WhatAmI(C.z_transport_whatami(loanedTransport)),
+		isQos:       bool(C.z_transport_is_qos(loanedTransport)),
+		isMulticast: bool(C.z_transport_is_multicast(loanedTransport)),
+		isShm:       bool(C.zc_cgo_transport_is_shm(loanedTransport)),
+	}
+	(*internal.ClosureContext[TransportEvent])(context).Call(evt)
+}
+
+//export zenohTransportEventsDrop
+func zenohTransportEventsDrop(context unsafe.Pointer) {
+	(*internal.ClosureContext[TransportEvent])(context).Drop()
+}
+
+//export zenohTransportCallback
+func zenohTransportCallback(transport *C.z_loaned_transport_t, context unsafe.Pointer) {
+	(*internal.ClosureContext[Transport])(context).Call(extractTransportSnapshot(transport))
+}
+
+//export zenohTransportDrop
+func zenohTransportDrop(context unsafe.Pointer) {
+	(*internal.ClosureContext[Transport])(context).Drop()
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// A Zenoh transport events listener.
+//
+// A listener that sends notifications when transports are connected or disconnected.
+type TransportEventsListener struct {
+	listener *C.z_owned_transport_events_listener_t
+	receiver <-chan TransportEvent
+}
+
+// Return transport events listener's receiver if it was constructed with channel, nil otherwise.
+func (listener *TransportEventsListener) Handler() <-chan TransportEvent {
+	return listener.receiver
+}
+
+// Destroy the transport events listener.
+// This is equivalent to calling [TransportEventsListener.Undeclare] and discarding its return value.
+func (listener *TransportEventsListener) Drop() {
+	C.z_transport_events_listener_drop(C.z_transport_events_listener_move(listener.listener))
+}
+
+// Undeclare and destroy the transport events listener.
+func (listener *TransportEventsListener) Undeclare() error {
+	res := int8(C.z_undeclare_transport_events_listener(C.z_transport_events_listener_move(listener.listener)))
+	if res == 0 {
+		return nil
+	}
+	return newZError(res)
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// Options for declaring a transport events listener.
+type TransportEventsListenerOptions struct {
+	History bool // If true, receive events for already-existing transports.
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// Fetch all transports currently connected to the session.
+func (session Session) Transports() ([]Transport, error) {
+	var transports []Transport
+
+	closure := internal.NewClosure(func(t Transport) { transports = append(transports, t) }, nil)
+	var cClosure C.z_owned_closure_transport_t
+	C.z_closure_transport(&cClosure, (*[0]byte)(C.zenohTransportCallback), (*[0]byte)(C.zenohTransportDrop), unsafe.Pointer(closure))
+	res := int8(C.z_info_transports(C.z_session_loan(session.session), C.z_closure_transport_move(&cClosure)))
+	if res != 0 {
+		return []Transport{}, newZError(res)
+	}
+	return transports, nil
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// Declare a transport events listener, registering a handler for transport connect/disconnect notifications.
+// Transport events listener MUST be explicitly destroyed using [TransportEventsListener.Undeclare] or [TransportEventsListener.Drop] once it is no longer needed.
+func (session *Session) DeclareTransportEventsListener(handler Handler[TransportEvent], options *TransportEventsListenerOptions) (TransportEventsListener, error) {
+	callback, drop, recv := handler.ToCbDropHandler()
+	closure := internal.NewClosure(callback, drop)
+	var cClosure C.z_owned_closure_transport_event_t
+	C.z_closure_transport_event(&cClosure, (*[0]byte)(C.zenohTransportEventsCallback), (*[0]byte)(C.zenohTransportEventsDrop), unsafe.Pointer(closure))
+
+	var cListener C.z_owned_transport_events_listener_t
+	var res int8
+	if options == nil {
+		res = int8(C.z_declare_transport_events_listener(C.z_session_loan(session.session), &cListener, C.z_closure_transport_event_move(&cClosure), nil))
+	} else {
+		var cOpts C.z_transport_events_listener_options_t
+		C.z_transport_events_listener_options_default(&cOpts)
+		cOpts.history = C.bool(options.History)
+		res = int8(C.z_declare_transport_events_listener(C.z_session_loan(session.session), &cListener, C.z_closure_transport_event_move(&cClosure), &cOpts))
+	}
+
+	if res == 0 {
+		return TransportEventsListener{listener: &cListener, receiver: recv}, nil
+	}
+	return TransportEventsListener{}, newZError(res)
+}
+
+// Warning: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+//
+// Declare a background transport events listener, registering a callback for transport connect/disconnect notifications.
+// The callback will be run in the background until the corresponding session is closed or dropped.
+func (session *Session) DeclareBackgroundTransportEventsListener(closure Closure[TransportEvent], options *TransportEventsListenerOptions) error {
+	listenerClosure := internal.NewClosure(closure.Call, closure.Drop)
+	var cClosure C.z_owned_closure_transport_event_t
+	C.z_closure_transport_event(&cClosure, (*[0]byte)(C.zenohTransportEventsCallback), (*[0]byte)(C.zenohTransportEventsDrop), unsafe.Pointer(listenerClosure))
+
+	var res int8
+	if options == nil {
+		res = int8(C.z_declare_background_transport_events_listener(C.z_session_loan(session.session), C.z_closure_transport_event_move(&cClosure), nil))
+	} else {
+		var cOpts C.z_transport_events_listener_options_t
+		C.z_transport_events_listener_options_default(&cOpts)
+		cOpts.history = C.bool(options.History)
+		res = int8(C.z_declare_background_transport_events_listener(C.z_session_loan(session.session), C.z_closure_transport_event_move(&cClosure), &cOpts))
+	}
+
+	if res == 0 {
+		return nil
+	}
+	return newZError(res)
+}

--- a/zenoh/zenoh_cgo.c
+++ b/zenoh/zenoh_cgo.c
@@ -111,6 +111,15 @@ void zc_cgo_bytes_read_all(const z_loaned_bytes_t *bytes, uint8_t *out) {
   z_bytes_reader_read(&reader, out, z_bytes_len(bytes));
 }
 
+bool zc_cgo_transport_is_shm(const z_loaned_transport_t *transport) {
+#if defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_SHARED_MEMORY)
+  return z_transport_is_shm(transport);
+#else
+  (void)transport;
+  return false;
+#endif
+}
+
 void zc_cgo_string_drop(z_owned_string_t *s) { z_drop(z_move(*s)); }
 
 void zc_cgo_encoding_drop(z_owned_encoding_t *e) { z_drop(z_move(*e)); }

--- a/zenoh/zenoh_cgo.c
+++ b/zenoh/zenoh_cgo.c
@@ -120,6 +120,18 @@ bool zc_cgo_transport_is_shm(const z_loaned_transport_t *transport) {
 #endif
 }
 
+void zc_cgo_create_transport(z_owned_transport_t *this_, z_id_t zid,
+                              z_whatami_t whatami, bool is_qos,
+                              bool is_multicast, bool is_shm) {
+#if defined(Z_FEATURE_UNSTABLE_API) && defined(Z_FEATURE_SHARED_MEMORY)
+  zc_internal_create_transport_shm(this_, zid, whatami, is_qos, is_multicast,
+                                   is_shm);
+#else
+  (void)is_shm;
+  zc_internal_create_transport(this_, zid, whatami, is_qos, is_multicast);
+#endif
+}
+
 void zc_cgo_string_drop(z_owned_string_t *s) { z_drop(z_move(*s)); }
 
 void zc_cgo_encoding_drop(z_owned_encoding_t *e) { z_drop(z_move(*e)); }

--- a/zenoh/zenoh_cgo.h
+++ b/zenoh/zenoh_cgo.h
@@ -152,6 +152,12 @@ extern void zenohLinkDrop(void *context);
 // Wrapper that returns false when Z_FEATURE_SHARED_MEMORY is not compiled in.
 bool zc_cgo_transport_is_shm(const z_loaned_transport_t *transport);
 
+// Wrapper that dispatches to zc_internal_create_transport_shm when shared memory is compiled in,
+// falling back to zc_internal_create_transport otherwise.
+void zc_cgo_create_transport(z_owned_transport_t *this_, z_id_t zid,
+                              z_whatami_t whatami, bool is_qos,
+                              bool is_multicast, bool is_shm);
+
 typedef struct zc_cgo_put_options_t {
   zc_internal_encoding_data_t encoding_data;
   zc_cgo_bytes_data_t attachment_data;

--- a/zenoh/zenoh_cgo.h
+++ b/zenoh/zenoh_cgo.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 ZettaScale Technology
+// Copyright (c) 2026 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -135,6 +135,22 @@ typedef const struct z_matching_status_t zc_cgo_const_matching_status;
 extern void zenohMatchingListenerCallback(zc_cgo_const_matching_status *status,
                                           void *context);
 extern void zenohMissListenerDrop(void *context);
+
+extern void zenohTransportEventsCallback(z_loaned_transport_event_t *event,
+                                         void *context);
+extern void zenohTransportEventsDrop(void *context);
+extern void zenohLinkEventsCallback(z_loaned_link_event_t *event,
+                                    void *context);
+extern void zenohLinkEventsDrop(void *context);
+
+extern void zenohTransportCallback(z_loaned_transport_t *transport,
+                                   void *context);
+extern void zenohTransportDrop(void *context);
+extern void zenohLinkCallback(z_loaned_link_t *link, void *context);
+extern void zenohLinkDrop(void *context);
+
+// Wrapper that returns false when Z_FEATURE_SHARED_MEMORY is not compiled in.
+bool zc_cgo_transport_is_shm(const z_loaned_transport_t *transport);
 
 typedef struct zc_cgo_put_options_t {
   zc_internal_encoding_data_t encoding_data;


### PR DESCRIPTION
Implemented connectivity API introduced to zenoh in https://github.com/eclipse-zenoh/zenoh/pull/2301  and distributed to other bindings in https://github.com/eclipse-zenoh/zenoh/issues/2451

This update depedns on updates below and must be corrected to point to main `zenoh-c` when updates below are merged:
- https://github.com/eclipse-zenoh/zenoh/pull/2556
- https://github.com/eclipse-zenoh/zenoh-c/pull/1265

Implemented in https://github.com/milyin-zenoh-zbobr/tasks/issues/54